### PR TITLE
feat: Recursive vault search across nested folders

### DIFF
--- a/Sources/Views/AssetGridView.swift
+++ b/Sources/Views/AssetGridView.swift
@@ -13,13 +13,38 @@ struct AssetGridView: View {
         store.assets.sorted { $0.creationDate > $1.creationDate }
     }
 
-    // Applies search filter when active
+    // Applies search filter when active — recursively searches into folder children
     private var assets: [Asset] {
         guard !searchText.isEmpty else { return allAssets }
-        let q = searchText.lowercased()
-        return allAssets.filter { asset in
+        return Self.searchAssets(allAssets, query: searchText)
+    }
+
+    /// Recursively searches assets and their children, flattening matches into a single list.
+    /// Folders that directly match are included. Non-matching folders have their matching
+    /// descendants surfaced to the top level.
+    static func searchAssets(_ assets: [Asset], query: String) -> [Asset] {
+        let q = query.lowercased()
+        var results: [Asset] = []
+        for asset in assets {
+            collectMatches(asset, query: q, into: &results)
+        }
+        return results
+    }
+
+    private static func collectMatches(_ asset: Asset, query q: String, into results: inout [Asset]) {
+        let selfMatches =
             (asset.name?.lowercased().contains(q) ?? false) ||
             (asset.textContent?.lowercased().contains(q) ?? false)
+
+        if selfMatches {
+            results.append(asset)
+            return
+        }
+
+        if asset.type == .folder, let children = asset.children {
+            for child in children {
+                collectMatches(child, query: q, into: &results)
+            }
         }
     }
 

--- a/Tests/ClipTests/SearchTests.swift
+++ b/Tests/ClipTests/SearchTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import Clip
+
+final class SearchTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeTree() -> [Asset] {
+        // Flat assets
+        let img = Asset(type: .image, imageData: Data(), name: "banner.png")
+        let txt = Asset(type: .text, textContent: "Hello world", name: "greeting.txt")
+
+        // Nested folder: Screenshots/ → logo-dark.svg
+        let nestedChild = Asset(type: .text, textContent: "<svg>...</svg>", name: "logo-dark.svg")
+        let folder = Asset(type: .folder, name: "Screenshots", children: [nestedChild])
+
+        // Deeply nested: Docs/ → Drafts/ → readme.md
+        let deepLeaf = Asset(type: .text, textContent: "# README", name: "readme.md")
+        let innerFolder = Asset(type: .folder, name: "Drafts", children: [deepLeaf])
+        let outerFolder = Asset(type: .folder, name: "Docs", children: [innerFolder])
+
+        return [img, txt, folder, outerFolder]
+    }
+
+    // MARK: - Tests
+
+    func testEmptyQueryReturnsEmpty() {
+        // Swift's String.contains("") returns false (NSString bridging).
+        // The caller (AssetGridView.assets) short-circuits with allAssets when
+        // searchText is empty, so searchAssets is never called with "".
+        // This test documents the behavior and verifies no crash.
+        let results = AssetGridView.searchAssets(makeTree(), query: "")
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testTopLevelNameMatch() {
+        let results = AssetGridView.searchAssets(makeTree(), query: "banner")
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].name, "banner.png")
+    }
+
+    func testTopLevelContentMatch() {
+        let results = AssetGridView.searchAssets(makeTree(), query: "hello")
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].name, "greeting.txt")
+    }
+
+    func testNestedChildMatch() {
+        // "logo" only exists inside Screenshots/ folder
+        let results = AssetGridView.searchAssets(makeTree(), query: "logo")
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].name, "logo-dark.svg")
+    }
+
+    func testDeeplyNestedMatch() {
+        // "readme" is inside Docs/ → Drafts/ → readme.md (2 levels deep)
+        let results = AssetGridView.searchAssets(makeTree(), query: "readme")
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].name, "readme.md")
+    }
+
+    func testFolderNameMatch() {
+        // "screenshots" matches the folder name directly
+        let results = AssetGridView.searchAssets(makeTree(), query: "screenshots")
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].name, "Screenshots")
+        XCTAssertEqual(results[0].type, .folder)
+    }
+
+    func testNoMatch() {
+        let results = AssetGridView.searchAssets(makeTree(), query: "nonexistent")
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testCaseInsensitive() {
+        let results = AssetGridView.searchAssets(makeTree(), query: "BANNER")
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].name, "banner.png")
+    }
+
+    func testMultipleMatches() {
+        // "d" matches: logo-dark.svg, Drafts folder, Docs folder
+        let results = AssetGridView.searchAssets(makeTree(), query: "draft")
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].name, "Drafts")
+    }
+
+    func testOriginalAssetsUnmutated() {
+        let tree = makeTree()
+        let originalChildCount = tree[2].children?.count  // Screenshots folder
+        _ = AssetGridView.searchAssets(tree, query: "logo")
+        XCTAssertEqual(tree[2].children?.count, originalChildCount, "Search must not mutate original assets")
+    }
+}

--- a/docs/plans/2026-04-09-001-feat-v1.4-multi-feature-plan.md
+++ b/docs/plans/2026-04-09-001-feat-v1.4-multi-feature-plan.md
@@ -1,0 +1,874 @@
+---
+title: "Clip v1.4.0 — Sparkle, Recursive Search, Image Formats, Markdown Files"
+type: feat
+status: active
+date: 2026-04-09
+issues:
+  - blacklogos/markutils#5
+  - blacklogos/markutils#6
+  - blacklogos/markutils#7
+  - blacklogos/markutils#8
+  - blacklogos/markutils#9
+version_target: 1.4.0
+---
+
+# Clip v1.4.0 — Multi-Feature Update
+
+## Overview
+
+Five open GitHub issues plan the next version of Clip. This plan groups them into four coherent phases that respect their dependencies and shared surface area, then sequences them so each phase ships independently:
+
+| Phase | Issues | Theme | Risk |
+|-------|--------|-------|------|
+| 1 | #6 | Recursive vault search | Low — pure filter logic |
+| 2 | #8, #9 | Markdown file preview/format/import | Medium — Asset model change + file I/O |
+| 3 | #7 | Image format conversion (SVG copy / PNG paste) | Medium — NSPasteboard contract |
+| 4 | #5 | Sparkle auto-update (replaces current UpdateChecker) | High — external framework, key management, release-process change |
+
+Phases are **independent** — each one can ship as a point release (1.3.1 → 1.3.2 → 1.3.3 → 1.4.0) without blocking on the next. Phase 4 is intentionally last because it changes the release pipeline itself.
+
+## Problem Statement
+
+After v1.3.0, five issues were filed across three distinct problem areas:
+
+1. **Discovery friction**: The vault search (`AssetGridView`) only matches top-level assets. Nested folders are invisible to the search filter (issue #6). Users with deep folder trees lose findability.
+2. **Markdown workflow gap**: Clip can preview pasted Markdown but cannot (a) open a `.md` file from disk, or (b) import a `.md` file as a first-class vault asset that remembers it's Markdown (issues #8, #9). Content creators working with existing drafts have to copy-paste manually.
+3. **Image format limits**: Image assets only copy as PNG and paste as PNG. There's no SVG export path and no explicit format conversion on paste (issue #7). Workflows that want vector output from raster sources, or PNG from clipboard TIFF/JPEG, currently require external tools.
+4. **Update infrastructure**: The v1.3.0 `UpdateChecker.swift` is a ~75-line hand-rolled GitHub Releases poller. It works but lacks delta updates, release notes UI, background install, progress reporting, signature verification of the download, and analytics. Issue #5 requests replacing it with Sparkle, the de-facto macOS auto-update framework, optionally proxied through stats.store for privacy-first telemetry.
+
+## Proposed Solution
+
+### Phase 1 — Recursive Vault Search (issue #6)
+
+Replace the flat filter in `AssetGridView.assets` with a recursive tree walk that keeps matching assets and the folder chain leading to them. Preserve existing behavior when `searchText` is empty (just sort by `creationDate`).
+
+**Behavior when searching:**
+- Match asset `name` or `textContent` (case-insensitive substring — same as current).
+- Recursively descend into `children` for folder assets. If any descendant matches, the folder stays in the result with children filtered to only matches.
+- Show matches flattened in the existing section headers (Folders / Images / Text). Matched items retain their section regardless of depth.
+- Optional polish: show a small breadcrumb (e.g., `📁 Screenshots/ → logo-dark.svg`) under the asset name when the match is nested.
+
+**Empty state**: "No results for '<query>'" — already handled by `ContentUnavailableView.search(text:)` at `AssetGridView.swift:194`.
+
+### Phase 2 — Markdown Files (issues #8 + #9)
+
+Treat these as one feature: **"Markdown-as-first-class content"**. They share an Asset model change (format metadata) and they share the same preview renderer.
+
+**Asset model changes** (Sources/Models/Asset.swift):
+- Add `var fileFormat: String?` — stores the canonical file extension without the dot (`"md"`, `"txt"`, `"html"`, `"json"`, ...). Optional, back-compat: existing assets decode with `nil` and render as plain text.
+- Keep `filePath` tracking out of scope for v1.4.0 — not worth the complexity of stale-file detection, cross-machine portability, or security-scoped URLs. File import is a one-way copy.
+- Mirror the new field in `VaultAsset` (Sources/ClipCLI/main.swift) so `clip export/import` round-trips correctly.
+
+**File import path** (Sources/Views/AssetGridView.swift `createAsset(from url:)`):
+- When importing a file whose UTType conforms to `.text` / `.plainText` / `.sourceCode`, capture `url.pathExtension.lowercased()` into the new `fileFormat` field.
+- This catches `.md`, `.markdown`, `.txt`, `.json`, `.swift`, etc., without special-casing any of them.
+
+**Preview / edit UX** (Sources/Views/AssetGridView.swift + TransformerView.swift):
+- Add a "Preview" context action to text assets whose `fileFormat` is `"md"` or `"markdown"`. Action opens the existing TransformerView split view with the asset's `textContent` pre-loaded and the preview pane rendered via `HTMLPreviewView`.
+- Add a "Markdown" badge (small Capsule, similar to the existing `detectedType` badge in QuickActionsView:54-62) on text assets with `fileFormat == "md"`.
+
+**File-picker path for issue #8** (Sources/Views/TransformerView.swift):
+- Add an "Open File…" button to `editorToolbar(title:text:isInput:)` when `selectedTransform == .textConversion` and `isInput == true`.
+- Clicking opens `NSOpenPanel` with `allowedContentTypes: [.markdown, .plainText, UTType("net.daringfireball.markdown")!]` (with a fallback if the UTType isn't registered).
+- Loaded text replaces `textInput`; the live preview handles rendering automatically via the existing `HTMLPreviewView(htmlContent: RichTextTransformer.markdownToHTML(textInput))` call at `TransformerView.swift:134`.
+
+**Drag-and-drop for issue #9**: already works via the existing `dropDestination(for: URL.self)` + `createAsset(from:)` at `AssetGridView.swift:178`. Once `createAsset` captures `fileFormat`, dropping a `.md` file just works — the badge and preview action automatically light up.
+
+### Phase 3 — Image Format Conversion (issue #7)
+
+Two independent NSPasteboard operations, both localized to image asset handling:
+
+**Copy as SVG (scope-limited version):**
+- Raster → true SVG conversion requires vector tracing and either a C library (potrace) or a substantial pure-Swift port. **Out of scope** for v1.4.0.
+- Instead, ship "Copy as SVG" only for assets whose underlying bytes are *already* SVG (text content that starts with `<svg` or `<?xml ... svg`). These exist when users import `.svg` files into the vault — file import currently stores them as text (since UTType svg conforms to `.text`). Copy action puts the raw SVG string on the pasteboard as `public.svg-image`.
+- Detection: `asset.type == .text && textContent?.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("<svg") == true`.
+- Document clearly in the changelog that raster-to-SVG tracing is a separate, future feature.
+
+**Paste as PNG:**
+- The existing `handlePaste` in AssetGridView already converts NSImage (whatever source format) → PNG via NSBitmapImageRep. Surface this as an explicit menu action with a clearer label ("Paste Image as PNG") for discoverability.
+- Add TIFF-on-clipboard detection (already handled in ClipboardMonitor.swift:64) and mirror that conversion pipeline so users pasting from Preview / screenshots always land as PNG.
+- Add a context menu on the Asset vault empty area: "Paste as PNG" — reads current clipboard, converts, imports.
+
+**New NSPasteboard types:** register `UTType.svg` in the existing `createItemProvider` drag path so SVG assets can also be dragged out to Finder / design tools.
+
+### Phase 4 — Sparkle Auto-Update (issue #5)
+
+Replace `Sources/Services/UpdateChecker.swift` with the Sparkle framework, wired through `SPUStandardUpdaterController` in AppDelegate. This is the highest-risk phase because it changes the release pipeline itself. See framework research in §"Technical Approach / Phase 4" below for full detail.
+
+**Ship in two releases:**
+1. **Bridge release (e.g. 1.3.1)** — keep the old UpdateChecker AND add Sparkle + Info.plist + appcast infrastructure. Existing 1.3.0 users get notified by the old checker; they manually download 1.3.1, which has Sparkle baked in.
+2. **Cutover release (1.4.0)** — delete UpdateChecker.swift entirely. From this point on, updates flow through Sparkle.
+
+## System-Wide Impact
+
+### Interaction Graph
+
+**Phase 1 (search)**:
+- `AssetGridView.searchText` change → `assets` computed property recomputes → SwiftUI re-renders sections. No callbacks or persistence.
+
+**Phase 2 (markdown files)**:
+- File import: `dropDestination` → `handleFileImport` → `createAsset(from url:)` → `AssetStore.add(asset)` → `assets.didSet` → `save()` → JSON write to `~/Library/Application Support/Clip/assets.json`.
+- The new `fileFormat` field flows through `Asset.encode(to:)` → on-disk JSON → `Asset.init(from:)` on next launch.
+- CLI roundtrip: `clip export` → `VaultAsset` decode → re-encode → JSON. `VaultAsset` must learn the same field or `clip export` silently drops it on roundtrip.
+- Preview action from vault: menu action → sets a `@State` binding on `TransformerView.textInput` → existing `.onTextChange` → `RichTextTransformer.markdownToHTML` → `HTMLPreviewView.loadHTMLString`.
+
+**Phase 3 (image formats)**:
+- Copy: menu action → `NSPasteboard.general.clearContents()` → `setData(_:forType:)` for `public.png` or `public.svg-image`. No async, no persistence.
+- Paste: menu action → `NSPasteboard.general.data(forType:)` → NSImage instantiation → NSBitmapImageRep PNG conversion → `Asset(type: .image, imageData: png)` → `AssetStore.add` → save.
+
+**Phase 4 (Sparkle)**:
+- Launch: `AppDelegate.init()` creates `SPUStandardUpdaterController(startingUpdater: true, ...)` → Sparkle schedules background check (configurable via `SUScheduledCheckInterval`) → HTTP GET of `SUFeedURL` → RSS parse → version compare against `CFBundleVersion` → if newer, present `SPUStandardUserDriver` UI → user clicks Install → download → EdDSA verify → mount DMG → replace app bundle → relaunch.
+- Menu action: `updaterController.checkForUpdates(_:)` is an `NSAction` that drives the same pipeline manually.
+- Release pipeline: every build now requires `sign_update <dmg>` to produce a signature, then the signature + length + URL appended to `appcast.xml` which is committed and served from `raw.githubusercontent.com`.
+
+### Error & Failure Propagation
+
+**Phase 1**: Search filtering cannot fail — it's pure computation on in-memory data.
+
+**Phase 2**:
+- `NSOpenPanel` cancel → no-op, `panel.runModal() != .OK` → early return.
+- File read failure → existing `try? Data(contentsOf: url)` returns nil → `createAsset` returns nil → import silently skips the file. **Gap**: user gets no feedback. Fix: show an NSAlert with the filename and error description.
+- JSON decode on app launch: if the new `fileFormat` is absent (old vaults from 1.3.0), `decodeIfPresent` returns nil. No crash.
+- Preview render: `RichTextTransformer.markdownToHTML` is total (no throws) — worst case, malformed markdown renders as plain text in a `<p>`. Acceptable.
+
+**Phase 3**:
+- Empty clipboard on paste → NSImage init returns nil → show "Nothing to paste" NSAlert. Don't silently fail.
+- Non-image pasteboard content → same path, same alert.
+- NSBitmapImageRep PNG conversion failure (rare; corrupted image) → show alert, don't corrupt the vault.
+- SVG copy on an asset that isn't actually SVG → the `hasPrefix("<svg")` guard prevents the menu action from even appearing. No error path.
+
+**Phase 4** (high risk):
+- Sparkle loads with invalid `SUPublicEDKey` → crash at `SPUStandardUpdaterController.init`. Mitigation: test on a clean machine before shipping.
+- Appcast 404 (typo in URL or GitHub outage) → Sparkle silently logs to system console; user sees nothing unless they manually check. Mitigation: smoke-test the URL from a second machine immediately after release.
+- Appcast `sparkle:version` lower than installed `CFBundleVersion` → Sparkle correctly treats as no-update. Mitigation: enforce monotonic `CFBundleVersion` in `build_dmg.sh` via a version file.
+- DMG download signature mismatch → Sparkle refuses the install and presents "The update is improperly signed". Root cause is usually `sign_update` run against a stale DMG or appcast edited by hand without re-signing. Mitigation: always use `generate_appcast` to avoid manual edits.
+- EdDSA private key loss → **unrecoverable** for existing users. Mitigation: export to 1Password immediately after `generate_keys`.
+
+### State Lifecycle Risks
+
+**Phase 2**: The Asset schema evolution is the only concrete risk. New field is additive and optional, so forward/backward compat is automatic *provided* `VaultAsset` in the CLI is updated in the same commit. Schema drift test (below) catches the divergence.
+
+**Phase 3**: None — operations are transactional per-asset.
+
+**Phase 4**: The bridge release strategy specifically exists to avoid stranding users. A single "cutover" release without a bridge would leave 1.3.0 users with a broken update checker (the custom one pointed at a specific endpoint, the new one at a different path).
+
+### API Surface Parity
+
+**Phase 2** (Markdown files) — two distinct entry points must stay in sync:
+- **GUI vault**: drag-drop / file picker in `AssetGridView` → `createAsset` → captures `fileFormat`.
+- **CLI vault**: `clip import` reads JSON that was either written by the GUI (has `fileFormat`) or by an older GUI version (doesn't). Both must round-trip cleanly.
+
+**Phase 3**: only the GUI surface has image-format operations. The CLI's `clip export`/`import` is oblivious to pasteboard conversions — they happen at the UI layer, not the storage layer.
+
+**Phase 4**: only the GUI uses Sparkle; the CLI remains static and has no self-update.
+
+### Integration Test Scenarios
+
+5 cross-layer scenarios unit tests cannot catch:
+
+1. **Deep folder search**: Create a folder tree 4 levels deep with a matching asset at the leaf. Search query matches only the leaf. Expected: the leaf is shown; intermediate folders may be collapsed or expanded, but navigating to the leaf must be possible.
+2. **Markdown round-trip across app restart**: Drop a `.md` file into the vault, quit the app, relaunch. Expected: asset still has `fileFormat == "md"` and the Markdown badge still shows. Validates JSON persistence of the new field.
+3. **CLI export/import preserves fileFormat**: `clip export > backup.json && clip import < backup.json`. Expected: `fileFormat` values survive the round-trip. Validates VaultAsset mirror is in sync.
+4. **Paste from Preview app**: Open a PNG in Preview, Cmd+C, switch to Clip, "Paste Image as PNG". Expected: image appears in vault with PNG bytes. Validates that NSImage → NSBitmapImageRep → PNG conversion handles arbitrary pasteboard image sources.
+5. **Sparkle end-to-end on a second machine**: Install 1.3.1 (bridge). Bump version locally to 1.3.2, sign DMG, update appcast.xml, push to GitHub. On the second machine, launch Clip 1.3.1 → wait for scheduled check OR click "Check for Updates" → expect prompt → install → relaunch → verify `CFBundleVersion == 5`. Validates the full Sparkle pipeline including EdDSA verification and code-signing continuity.
+
+## Technical Approach
+
+### Phase 1 — Recursive Search
+
+File: `Sources/Views/AssetGridView.swift`
+
+Current code (lines 17-24):
+```swift
+private var assets: [Asset] {
+    guard !searchText.isEmpty else { return allAssets }
+    let q = searchText.lowercased()
+    return allAssets.filter { asset in
+        (asset.name?.lowercased().contains(q) ?? false) ||
+        (asset.textContent?.lowercased().contains(q) ?? false)
+    }
+}
+```
+
+Replacement:
+```swift
+private var assets: [Asset] {
+    guard !searchText.isEmpty else { return allAssets }
+    let q = searchText.lowercased()
+    return allAssets.compactMap { filterTree($0, query: q) }
+}
+
+/// Recursively searches an asset and its children. Returns:
+/// - the asset unchanged if it directly matches
+/// - a folder with filtered children if any descendant matches
+/// - nil if nothing in this subtree matches
+private func filterTree(_ asset: Asset, query q: String) -> Asset? {
+    let selfMatches =
+        (asset.name?.lowercased().contains(q) ?? false) ||
+        (asset.textContent?.lowercased().contains(q) ?? false)
+
+    if asset.type == .folder {
+        let filteredChildren = (asset.children ?? []).compactMap { filterTree($0, query: q) }
+        if selfMatches || !filteredChildren.isEmpty {
+            // Return a shallow clone that replaces children with the filtered subset.
+            // Do NOT mutate the original — that would corrupt AssetStore.
+            return Asset(
+                type: .folder,
+                name: asset.name,
+                children: filteredChildren
+            )
+        }
+        return nil
+    }
+
+    return selfMatches ? asset : nil
+}
+```
+
+**Gotcha**: `filterTree` must NOT mutate the original Asset. The `AssetStore.assets.didSet` trigger would fire and persist the filtered view as if it were real data. The shallow-clone approach above sidesteps this — but because `Asset` is `@Observable final class`, the clone loses the original's `id` and `creationDate`. Fix: extend `Asset` with a `clonedForFilter()` helper that preserves `id` and `creationDate`, OR stop treating the filter result as Assets and use a parallel `AssetDisplayNode` value type. The display-node approach is cleaner.
+
+Alternative (cleaner): introduce a simple display-node value type scoped to AssetGridView:
+```swift
+// Private to AssetGridView.swift
+private struct AssetNode: Identifiable {
+    let id: UUID            // mirrors Asset.id for stable SwiftUI identity
+    let asset: Asset        // original reference for actions
+    let children: [AssetNode]
+}
+```
+
+The sections and ForEach views switch from `[Asset]` to `[AssetNode]`. This adds a small translation layer but eliminates the mutation risk.
+
+**Decision**: use `AssetNode`. It's boring and obvious (per AGENT_RULES philosophy).
+
+### Phase 2 — Markdown Files
+
+**Step 1: Schema evolution** — `Sources/Models/Asset.swift`
+
+```swift
+@Observable
+final class Asset: Identifiable, Codable {
+    var id: UUID
+    var creationDate: Date
+    var type: AssetType
+    var textContent: String?
+    var imageData: Data?
+    var name: String?
+    var children: [Asset]?
+    var fileFormat: String?    // NEW: canonical extension without dot ("md", "txt", "json")
+
+    init(type: AssetType,
+         textContent: String? = nil,
+         imageData: Data? = nil,
+         name: String? = nil,
+         children: [Asset]? = nil,
+         fileFormat: String? = nil) {
+        self.id = UUID()
+        self.creationDate = Date()
+        self.type = type
+        self.textContent = textContent
+        self.imageData = imageData
+        self.name = name
+        self.children = children
+        self.fileFormat = fileFormat
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, creationDate, type, textContent, imageData, name, children, fileFormat
+    }
+
+    required init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(UUID.self, forKey: .id)
+        self.creationDate = try c.decode(Date.self, forKey: .creationDate)
+        self.type = try c.decode(AssetType.self, forKey: .type)
+        self.textContent = try c.decodeIfPresent(String.self, forKey: .textContent)
+        self.imageData = try c.decodeIfPresent(Data.self, forKey: .imageData)
+        self.name = try c.decodeIfPresent(String.self, forKey: .name)
+        self.children = try c.decodeIfPresent([Asset].self, forKey: .children)
+        self.fileFormat = try c.decodeIfPresent(String.self, forKey: .fileFormat)  // NEW, optional
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(creationDate, forKey: .creationDate)
+        try c.encode(type, forKey: .type)
+        try c.encodeIfPresent(textContent, forKey: .textContent)
+        try c.encodeIfPresent(imageData, forKey: .imageData)
+        try c.encodeIfPresent(name, forKey: .name)
+        try c.encodeIfPresent(children, forKey: .children)
+        try c.encodeIfPresent(fileFormat, forKey: .fileFormat)  // NEW
+    }
+}
+```
+
+**Step 2: VaultAsset mirror** — `Sources/ClipCLI/main.swift`
+
+```swift
+struct VaultAsset: Codable {
+    let id: UUID
+    let creationDate: Date
+    let type: String
+    let textContent: String?
+    let imageData: Data?
+    let name: String?
+    let children: [VaultAsset]?
+    let fileFormat: String?   // NEW
+}
+```
+
+**Step 3: File import** — `Sources/Views/AssetGridView.swift`, `createAsset(from url:)` (around line 373)
+
+```swift
+} else if type.conforms(to: .text) || type.conforms(to: .plainText) || type.conforms(to: .sourceCode) {
+    if let data = try? Data(contentsOf: url),
+       let text = String(data: data, encoding: .utf8) {
+        let ext = url.pathExtension.lowercased()
+        return Asset(
+            type: .text,
+            textContent: text,
+            name: name,
+            fileFormat: ext.isEmpty ? nil : ext    // NEW
+        )
+    }
+}
+```
+
+**Step 4: Markdown badge** — `Sources/Views/AssetGridView.swift`, inside `AssetItemView.body` alongside the clipboard clock badge:
+
+```swift
+if asset.fileFormat == "md" || asset.fileFormat == "markdown" {
+    Text("MD")
+        .font(.system(size: 9, weight: .bold))
+        .padding(.horizontal, 4)
+        .padding(.vertical, 1)
+        .background(Color.blue.opacity(0.8))
+        .foregroundStyle(.white)
+        .clipShape(Capsule())
+        .padding(4)
+}
+```
+
+**Step 5: Preview action** — a context menu item on `AssetItemView` and `CompactAssetRowView` when `asset.fileFormat` is markdown:
+
+```swift
+.contextMenu {
+    if asset.type == .text,
+       let fmt = asset.fileFormat,
+       fmt == "md" || fmt == "markdown" {
+        Button("Preview Rendered") {
+            openInTransformerForPreview(asset)
+        }
+    }
+    // ... existing context actions
+}
+```
+
+`openInTransformerForPreview` requires the root `ContentView` to expose a tab-switching path. Two ways:
+- **Simpler**: hoist `selectedTab` and a shared `pendingMarkdownForPreview: String?` up to `ContentView` via `@Observable` view model or a simple singleton. Context action sets the text, flips the tab to 1 (Transform).
+- **Cleaner**: pass an `onPreview: (Asset) -> Void` closure through the view hierarchy from ContentView.
+
+**Decision**: singleton `MarkdownPreviewRouter` (`@Observable`) scoped to the app, initialized in ClipApp.swift. Matches the existing `AssetStore.shared` pattern.
+
+```swift
+// Sources/Models/MarkdownPreviewRouter.swift (new)
+import Foundation
+import Observation
+
+@Observable
+final class MarkdownPreviewRouter {
+    static let shared = MarkdownPreviewRouter()
+    var pendingText: String? = nil
+    func request(_ text: String) { pendingText = text }
+    func consume() -> String? { defer { pendingText = nil }; return pendingText }
+}
+```
+
+TransformerView reads `MarkdownPreviewRouter.shared.pendingText` in `.onAppear` and in `.onChange(of:)` to hydrate `textInput` when it's non-nil.
+
+**Step 6: File picker in TransformerView** — `Sources/Views/TransformerView.swift`, add to `editorToolbar` when `isInput`:
+
+```swift
+if isInput {
+    Button(action: openMarkdownFile) {
+        Image(systemName: "folder.badge.plus")
+    }
+    .buttonStyle(.plain)
+    .help("Open Markdown file…")
+}
+
+private func openMarkdownFile() {
+    let panel = NSOpenPanel()
+    panel.canChooseFiles = true
+    panel.canChooseDirectories = false
+    panel.allowsMultipleSelection = false
+    if let mdType = UTType(filenameExtension: "md") {
+        panel.allowedContentTypes = [mdType, .plainText]
+    } else {
+        panel.allowedContentTypes = [.plainText]
+    }
+
+    guard panel.runModal() == .OK, let url = panel.url else { return }
+
+    do {
+        let text = try String(contentsOf: url, encoding: .utf8)
+        textInput = text
+        transform()
+    } catch {
+        let alert = NSAlert(error: error)
+        alert.messageText = "Couldn't open \(url.lastPathComponent)"
+        alert.runModal()
+    }
+}
+```
+
+### Phase 3 — Image Formats
+
+**SVG copy** — in `AssetItemView.copyAsset()` (line 561) and `CompactAssetRowView.copyAsset()` (line 702):
+
+```swift
+private func copyAsset() {
+    let pb = NSPasteboard.general
+    pb.clearContents()
+
+    if asset.type == .image, let data = asset.imageData {
+        pb.setData(data, forType: .png)
+    } else if asset.type == .text, let text = asset.textContent {
+        let isSVG = text.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("<svg")
+            || text.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("<?xml")
+        if isSVG {
+            pb.setString(text, forType: NSPasteboard.PasteboardType("public.svg-image"))
+            pb.setString(text, forType: .string)   // fallback for apps that don't understand SVG
+        } else {
+            pb.setString(text, forType: .string)
+        }
+    }
+    flash()
+}
+```
+
+Context menu gains a conditional "Copy as SVG" only when `isSVG` is true — avoids confusing users with an option that doesn't apply.
+
+**Paste as PNG** — new action in `AssetGridView.swift`:
+
+```swift
+private func pasteAsPNG() {
+    let pb = NSPasteboard.general
+    guard let image = NSImage(pasteboard: pb),
+          let tiff = image.tiffRepresentation,
+          let bitmap = NSBitmapImageRep(data: tiff),
+          let png = bitmap.representation(using: .png, properties: [:]) else {
+        showAlert(title: "Nothing to paste", message: "Clipboard doesn't contain an image.")
+        return
+    }
+    let asset = Asset(type: .image, imageData: png, name: "Pasted Image")
+    store.add(asset)
+}
+```
+
+Wire into the existing `.onPasteCommand` at line 186 (transparent — pasting an image already works) and also add an explicit "Paste Image as PNG" in a new top-level toolbar menu button, so the feature is discoverable.
+
+**Drag-out SVG**: extend `createItemProvider` at `AssetGridView.swift:216` so text assets marked as SVG register both `public.plain-text` and `public.svg-image`:
+
+```swift
+if asset.type == .text, let text = asset.textContent {
+    let isSVG = text.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("<svg")
+    let svgType = "public.svg-image"
+    let plainType = UTType.plainText.identifier
+
+    if isSVG {
+        provider.registerDataRepresentation(forTypeIdentifier: svgType, visibility: .all) { completion in
+            completion(text.data(using: .utf8), nil)
+            return nil
+        }
+    }
+    provider.registerDataRepresentation(forTypeIdentifier: plainType, visibility: .all) { completion in
+        completion(text.data(using: .utf8), nil)
+        return nil
+    }
+}
+```
+
+### Phase 4 — Sparkle
+
+**Package.swift**:
+```swift
+dependencies: [
+    .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.1"),
+],
+targets: [
+    .target(name: "ClipCore", path: "Sources/ClipCore"),
+    .executableTarget(
+        name: "Clip",
+        dependencies: [
+            "ClipCore",
+            .product(name: "Sparkle", package: "Sparkle"),
+        ],
+        path: "Sources",
+        exclude: ["ClipCore", "ClipCLI"]
+    ),
+    // ClipCLI target unchanged — no Sparkle dependency
+    // ClipTests target unchanged
+]
+```
+
+**AppDelegate wiring**:
+```swift
+import Sparkle
+
+final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
+    let updaterController: SPUStandardUpdaterController
+
+    override init() {
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        super.init()
+    }
+
+    // Existing applicationDidFinishLaunching — replace the manual update menu item:
+    func setupMenu() {
+        let menu = NSMenu()
+        // ... existing items ...
+
+        let checkForUpdates = NSMenuItem(
+            title: "Check for Updates…",
+            action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
+            keyEquivalent: "u"
+        )
+        checkForUpdates.target = updaterController
+        menu.addItem(checkForUpdates)
+
+        // remove the old @objc func checkForUpdates() method
+    }
+}
+```
+
+**Info.plist additions** (in `scripts/build_dmg.sh` heredoc):
+```xml
+<key>CFBundleIdentifier</key>
+<string>io.blacklogos.clip</string>                    <!-- FIX: was com.example.Clip -->
+
+<key>SUFeedURL</key>
+<string>https://raw.githubusercontent.com/blacklogos/markutils/main/appcast.xml</string>
+
+<key>SUPublicEDKey</key>
+<string>REPLACE_WITH_ACTUAL_KEY_AFTER_generate_keys</string>
+
+<key>SUEnableAutomaticChecks</key>
+<true/>
+
+<key>SUScheduledCheckInterval</key>
+<integer>86400</integer>
+
+<key>SUAllowsAutomaticUpdates</key>
+<true/>
+```
+
+**build_dmg.sh additions**:
+1. `swift package resolve` (ensures Sparkle artifacts exist).
+2. Define `SPARKLE_ART=".build/artifacts/sparkle-project/Sparkle"` — path may differ slightly; verify with `find .build/artifacts -name 'Sparkle.framework' -print`.
+3. `mkdir -p "${APP_BUNDLE}/Contents/Frameworks"` and `cp -R "$SPARKLE_FRAMEWORK" "${APP_BUNDLE}/Contents/Frameworks/"`.
+4. `codesign --force --deep --sign - "${APP_BUNDLE}/Contents/Frameworks/Sparkle.framework"` BEFORE the outer `codesign --force --deep --sign - "${APP_BUNDLE}"`.
+5. After DMG creation: `"${SPARKLE_ART}/bin/sign_update" "${DMG_NAME}"` — prints `sparkle:edSignature="..."` and `length=NNNN`. Capture and append a new `<item>` to `appcast.xml`, OR use `generate_appcast` against a `releases/` directory.
+6. Commit the updated `appcast.xml` alongside the tag.
+
+**EdDSA key management (one-time):**
+1. `./.build/artifacts/sparkle-project/Sparkle/bin/generate_keys` — creates Keychain item "https://sparkle-project.org".
+2. `generate_keys -x sparkle_private_key.pem` — exports the private key to a PEM file.
+3. Store the PEM in 1Password, then `rm sparkle_private_key.pem`. **Do not commit it.** Add `*.pem` to `.gitignore` as belt-and-suspenders.
+4. `generate_keys` printed the public key — paste it into the Info.plist template in `build_dmg.sh`.
+
+**Bridge release (1.3.1) strategy:**
+- Keep `Sources/Services/UpdateChecker.swift` intact.
+- Keep the existing "Check for Updates…" menu action pointing at the old checker.
+- Add Sparkle as a parallel, SILENT updater: `startingUpdater: false`, no menu item yet. This ships the framework and Info.plist keys but doesn't activate them.
+- Users on 1.3.0 still get notified by the old checker. They download 1.3.1 manually.
+- In 1.4.0, flip `startingUpdater: true`, delete the old UpdateChecker, add the Sparkle-driven menu item.
+
+**stats.store decision**: **defer**. Proxy requires emailing Peter Steinberger to register the bundle ID and is permanent. Ship the first Sparkle release pointed directly at `raw.githubusercontent.com` and switch to stats.store in a later point release once the flow is stable.
+
+## Implementation Phases
+
+### Phase 1: Recursive Search (issue #6) — ships as 1.3.1
+
+**Scope**: Filter logic only. No persistence or schema changes.
+
+**Tasks:**
+1. Introduce `AssetNode` value type inside `AssetGridView.swift`
+2. Write `filterTree(_ asset: Asset, query: String) -> AssetNode?`
+3. Refactor `folderAssets`/`imageAssets`/`textAssets` computed properties to work on `[AssetNode]` when searching
+4. Add unit tests in `Tests/ClipTests/SearchTests.swift` for:
+   - Empty query returns all assets unchanged
+   - Single-level match
+   - Match on nested child (returns folder chain)
+   - No match returns empty
+   - Case-insensitive match
+5. `./scripts/verify_release.sh`
+
+**Success criteria**: typing any substring in the vault search finds assets at any depth.
+
+### Phase 2: Markdown Files (issues #8 + #9) — ships as 1.3.2
+
+**Scope**: Asset schema extension, file import, preview flow, file picker in Transform tab.
+
+**Tasks:**
+1. Add `fileFormat: String?` to `Asset.swift` with full Codable support
+2. Add `fileFormat: String?` to `VaultAsset` in ClipCLI/main.swift (keep in sync)
+3. Update `AssetGridView.createAsset(from url:)` to populate `fileFormat` from `url.pathExtension`
+4. Add MD badge overlay in `AssetItemView.body`
+5. Create `Sources/Models/MarkdownPreviewRouter.swift` as `@Observable` singleton
+6. Wire router into `ContentView.swift` — on router state change, set `selectedTab = 1`
+7. Wire router into `TransformerView.swift` — consume `pendingText` into `textInput`
+8. Add context menu "Preview Rendered" on MD assets in AssetItemView and CompactAssetRowView
+9. Add "Open File…" button (`folder.badge.plus` system image) to TransformerView editor toolbar
+10. Implement `openMarkdownFile()` with NSOpenPanel
+11. Tests in `Tests/ClipTests/AssetFormatTests.swift`:
+    - Asset decodes from old JSON (no `fileFormat` key) without error
+    - Asset encodes `fileFormat` when set
+    - VaultAsset round-trips `fileFormat` via JSON
+    - `createAsset` captures extension for .md files (mock URL)
+12. `./scripts/verify_release.sh`
+
+**Success criteria**: dropping an `.md` file into the vault shows an MD badge; right-clicking reveals "Preview Rendered" which opens the Transform tab with the markdown pre-loaded and rendered in the split-view preview.
+
+### Phase 3: Image Format Conversion (issue #7) — ships as 1.3.3
+
+**Scope**: NSPasteboard contract changes only. No schema or persistence impact.
+
+**Tasks:**
+1. Add SVG detection helper in AssetGridView (`isSVG(_ text: String) -> Bool`)
+2. Update `AssetItemView.copyAsset()` and `CompactAssetRowView.copyAsset()` to register SVG pasteboard type when applicable
+3. Add conditional "Copy as SVG" context menu item
+4. Implement `pasteAsPNG()` action on AssetGridView
+5. Add "Paste as PNG" toolbar button OR context menu on empty vault area
+6. Extend `createItemProvider` to register `public.svg-image` for SVG text assets
+7. Error alert for empty/invalid clipboard
+8. Tests:
+   - SVG detection handles `<svg`, `<?xml ... svg`, with and without whitespace
+   - `pasteAsPNG` converts a NSImage to PNG bytes (uses a fixture PNG loaded from disk)
+9. Manual test: copy from Preview.app / Screenshot → Paste as PNG → verify asset appears as PNG
+10. `./scripts/verify_release.sh`
+
+**Success criteria**: importing an SVG file into the vault and right-clicking reveals "Copy as SVG"; pasting a screenshot from the system clipboard creates a PNG asset.
+
+### Phase 4: Sparkle Auto-Update (issue #5) — ships as 1.3.4 (bridge) then 1.4.0 (cutover)
+
+**Scope**: HIGH RISK. Changes the release pipeline and requires key management.
+
+**Tasks (bridge release 1.3.4):**
+1. **Preflight**:
+   - Fix `CFBundleIdentifier` from `com.example.Clip` to a real reverse-DNS ID (e.g. `io.blacklogos.clip`)
+   - Add `*.pem` to `.gitignore`
+2. **Key generation (one-time, local only)**:
+   - Add Sparkle dependency to Package.swift
+   - `swift package resolve`
+   - Run `generate_keys` from the resolved artifacts
+   - Export private key with `-x`, store in 1Password, delete the file
+   - Copy the printed public key into build_dmg.sh Info.plist template
+3. **Framework bundling in build_dmg.sh**:
+   - Add `swift package resolve` at top
+   - Locate and copy Sparkle.framework into `Clip.app/Contents/Frameworks/`
+   - Code-sign the framework BEFORE the outer bundle
+4. **Info.plist additions** (SUFeedURL, SUPublicEDKey, SUEnableAutomaticChecks, SUScheduledCheckInterval, SUAllowsAutomaticUpdates)
+5. **AppDelegate changes**:
+   - Add `SPUStandardUpdaterController` property
+   - Initialize with `startingUpdater: false` for bridge release (dormant)
+   - Keep the old `UpdateChecker.checkForUpdate()` wired to the existing menu item
+6. **Appcast infrastructure**:
+   - Create empty `appcast.xml` in repo root with RSS skeleton and empty `<channel>`
+   - Commit it
+7. **Build + sign + publish**:
+   - Build 1.3.4 DMG normally
+   - Run `sign_update Clip-1.3.4.dmg` to get signature
+   - Add an `<item>` to `appcast.xml` pointing at the 1.3.4 release DMG
+   - Commit appcast.xml change
+   - Create GitHub release tag v1.3.4, upload DMG
+8. **Smoke test**: on a second Mac, install 1.3.3 manually, manually test that the old UpdateChecker still points users to 1.3.4
+9. `./scripts/verify_release.sh`
+
+**Tasks (cutover release 1.4.0):**
+1. Delete `Sources/Services/UpdateChecker.swift`
+2. Delete the old `@objc func checkForUpdates()` in AppDelegate
+3. Change `SPUStandardUpdaterController` init to `startingUpdater: true`
+4. Add new "Check for Updates…" menu item targeting `updaterController`
+5. Build 1.4.0, sign with `sign_update`, append to `appcast.xml`, commit, push, release
+6. **Smoke test end-to-end**: on a second Mac with 1.3.4 installed, wait for background check OR click "Check for Updates" → observe Sparkle prompt → accept → observe download/install/relaunch → verify 1.4.0 is running
+7. `./scripts/verify_release.sh`
+
+**Success criteria**: a user on 1.3.4 sees the Sparkle update prompt for 1.4.0, accepts, and relaunches into 1.4.0 without manually downloading a DMG.
+
+## Alternative Approaches Considered
+
+**Phase 1 — Search alternatives:**
+- **Breadth-first flatten with match-path**: flatten the tree into a list of `(asset, path: [String])` and filter that list. Shows every match with a breadcrumb but loses the folder grouping in the sectioned UI. Rejected: uglier UX for the common case.
+- **Core Spotlight index**: over-engineered for a ~100-asset vault.
+
+**Phase 2 — Markdown alternatives:**
+- **Persistent file path reference**: store the original file URL and re-read on open. Rejected: security-scoped bookmarks on macOS are intricate, can fail silently when the user moves the file, and don't work across machines when the vault is exported/imported.
+- **Separate `MarkdownAsset` subtype**: adds a new case to `AssetType`. Rejected: the existing text asset type already handles storage; a format hint is enough to distinguish rendering behavior.
+- **Full CommonMark parser**: pull in swift-markdown. Rejected: adds a dependency for a rendering path that the existing custom parser already handles. Revisit if users file bugs about specific Markdown features that don't render.
+
+**Phase 3 — Image format alternatives:**
+- **Raster → SVG vectorization**: would require a C library (potrace) or a substantial Swift port. Rejected: out of scope for v1.4.0.
+- **Store multiple encodings per asset**: keep both original and PNG in the asset. Rejected: doubles vault size for no clear benefit.
+
+**Phase 4 — Update alternatives:**
+- **Keep custom UpdateChecker and ignore #5**: Rejected per user request; also, the current checker misses delta updates, background install, and signed verification.
+- **Use Electron-style auto-update service (Squirrel.mac)**: Rejected; Sparkle is more mature on macOS and doesn't require an update server.
+- **Homebrew cask as sole distribution**: Rejected — Homebrew is fine as a parallel channel but doesn't address direct DMG users.
+
+## Acceptance Criteria
+
+### Phase 1 (1.3.1 — Recursive Search)
+- [ ] Typing any substring in the vault search finds assets nested at any depth
+- [ ] Search filter does not mutate `AssetStore.assets`
+- [ ] Empty search returns assets unchanged (same sort order as before)
+- [ ] Empty state shows "No results for '<query>'" when search has no matches
+- [ ] Unit tests pass for: empty query, top-level match, nested match (2+ levels), no match, case-insensitive match
+
+### Phase 2 (1.3.2 — Markdown Files)
+- [ ] `Asset.fileFormat: String?` is populated for all newly imported files (via extension)
+- [ ] Old vaults (no `fileFormat` in JSON) load without error — the field decodes as nil
+- [ ] `VaultAsset` in ClipCLI round-trips `fileFormat` through `clip export` / `clip import`
+- [ ] `.md` files dropped into the vault show a "MD" badge
+- [ ] Right-clicking an `.md` asset shows "Preview Rendered"; selecting it switches to Transform tab with preview rendered
+- [ ] "Open File…" button in TransformerView editor toolbar opens NSOpenPanel filtered to `.md` / `.txt`
+- [ ] Opened file content loads into the editor and renders in the preview
+- [ ] Unit tests pass for: Asset backwards compatibility, VaultAsset round-trip, file extension capture
+
+### Phase 3 (1.3.3 — Image Formats)
+- [ ] "Copy as SVG" appears in context menu only when asset is a text asset containing SVG markup
+- [ ] SVG copy writes to pasteboard as `public.svg-image` (verified by pasting into a design tool that supports SVG)
+- [ ] "Paste as PNG" imports any clipboard image as a PNG-encoded asset
+- [ ] Empty clipboard paste shows an alert instead of silently failing
+- [ ] SVG drag-out registers `public.svg-image` NSItemProvider data representation
+- [ ] Unit tests pass for: SVG detection (positive/negative), paste-as-PNG using a fixture image
+
+### Phase 4 (1.3.4 bridge + 1.4.0 cutover — Sparkle)
+- [ ] `CFBundleIdentifier` is a real reverse-DNS ID (not `com.example.Clip`)
+- [ ] EdDSA private key backed up in 1Password; public key in `build_dmg.sh` Info.plist template
+- [ ] `*.pem` is gitignored
+- [ ] `appcast.xml` exists at repo root and is committed
+- [ ] 1.3.4 DMG includes `Sparkle.framework` in `Contents/Frameworks/` and is code-signed
+- [ ] Existing UpdateChecker still works in 1.3.4 (bridge compatibility verified on a clean install)
+- [ ] 1.4.0 DMG replaces UpdateChecker with Sparkle as the sole update mechanism
+- [ ] End-to-end Sparkle update test passes on a second machine: 1.3.4 → prompt → install → relaunch into 1.4.0
+- [ ] `./scripts/verify_release.sh` passes for every release
+
+### Quality Gates (all phases)
+- [ ] Every phase ships only when `./scripts/verify_release.sh` passes
+- [ ] Swift build has no new warnings beyond the existing deprecation warning on `activateIgnoringOtherApps`
+- [ ] CHANGELOG.md is updated before each release tag
+- [ ] README.md version is bumped
+- [ ] DMG is built, landing page is redeployed, GitHub release is created
+
+## Success Metrics
+
+- **Phase 1**: Manual test with a 3-level folder tree: typing any leaf name finds the leaf in under 1 second.
+- **Phase 2**: Open an existing `.md` file from disk in <5 seconds (file picker → rendered preview).
+- **Phase 3**: Paste-from-Preview-to-vault works in a single menu click.
+- **Phase 4**: On a second machine running 1.3.4, the Sparkle update prompt for 1.4.0 appears within one hour (`SUScheduledCheckInterval=86400` means at most 24h; manual check should be instant).
+
+## Dependencies & Prerequisites
+
+- **Swift 5.9** — already baseline
+- **macOS 14+** — already baseline
+- **Sparkle 2.9.1+** — new dependency (Phase 4 only)
+- **sparkle-project.org tools** — `generate_keys`, `sign_update`, `generate_appcast` (come with the SPM package artifact)
+- **1Password or equivalent secure storage** — for the EdDSA private key
+- **Second Mac for end-to-end testing** — Phase 4 smoke test requires testing cross-machine
+
+## Risk Analysis & Mitigation
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Asset schema drift between app and CLI | Silent data loss on `clip export`/`import` | Medium | Add `VaultAssetSchemaTests` that encode an Asset and decode as VaultAsset, failing on mismatch |
+| Filter mutation of AssetStore | Vault corruption | Medium | Use `AssetNode` value type; never mutate original Asset inside filterTree |
+| Sparkle framework fails to load with ad-hoc signing | Cutover release bricks update path | Medium | Test end-to-end on a second Mac BEFORE releasing 1.4.0; maintain 1.3.4 as a fallback |
+| Loss of EdDSA private key | Cannot ship any future updates | Low but permanent | Export immediately after generate_keys; store in 1Password; document recovery procedure |
+| Appcast XML hand-edit breaks signature | Updates silently rejected with "improperly signed" | Medium | Use `generate_appcast` tool; never hand-edit `<enclosure>` attributes |
+| `CFBundleVersion` regression in build_dmg.sh | Sparkle treats bump as no-op | Medium | Derive `CFBundleVersion` from a counter file or from `VERSION` string; add a sanity check in verify_release.sh |
+| `com.example.Clip` bundle ID gets permanent once users register | stats.store + macOS associate wrong ID | Low but embarrassing | Fix BEFORE the bridge release (1.3.4) — in the same commit as Sparkle |
+| Raster SVG expectation mismatch | Users may file a bug if "Copy as SVG" does nothing on image assets | Medium | Document clearly in CHANGELOG that SVG export only works for SVG-content text assets; hide the menu item for non-SVG assets entirely |
+
+## Resource Requirements
+
+- Solo developer, local Mac
+- ~1 day per phase for implementation + testing
+- Second Mac for Phase 4 Sparkle end-to-end test
+- Total: 4-5 working days across the four phases
+
+## Future Considerations
+
+- **Phase 5 (next cycle)**: Raster → SVG vectorization via potrace bindings
+- **Phase 5**: stats.store integration once the core Sparkle flow is stable
+- **Phase 5**: Delta updates (Sparkle supports binary patch files, needs additional build step)
+- **Phase 6**: Sync vault across Macs (iCloud Drive file coordination or CloudKit)
+- **Phase 6**: Open MD files with live file-watching (re-read on disk change)
+
+## Documentation Plan
+
+- [ ] `CHANGELOG.md` — entry per phase release (1.3.1 / 1.3.2 / 1.3.3 / 1.3.4 / 1.4.0)
+- [ ] `README.md` — update feature list and architecture section for each phase
+- [ ] `docs/clip-cli.md` — no changes needed until schema drift affects CLI output
+- [ ] `docs/index.html` (landing page) — feature cards for recursive search, markdown file preview, SVG/PNG; redeploy to clip.cc4.marketing via wrangler after each phase
+- [ ] New solution doc after Phase 4: `docs/solutions/best-practice/sparkle-integration-ad-hoc-signing-20260415.md` documenting the framework bundling, codesign ordering, EdDSA key management, and bridge-release strategy
+
+## Sources & References
+
+### Internal References
+
+- `Sources/Models/Asset.swift` — Asset model with @Observable + Codable
+- `Sources/Views/AssetGridView.swift:17-24` — current (non-recursive) search filter
+- `Sources/Views/AssetGridView.swift:354-404` — `createAsset(from url:)` file import path
+- `Sources/Views/AssetGridView.swift:216-248` — NSItemProvider drag-out pattern
+- `Sources/Views/AssetGridView.swift:561-575` — `AssetItemView.copyAsset()` current PNG-only copy
+- `Sources/Views/TransformerView.swift:107-139` — text conversion split view + HTMLPreviewView wiring
+- `Sources/Views/HTMLPreviewView.swift` — WKWebView rendering conventions
+- `Sources/ClipCLI/main.swift` — VaultAsset mirror type (must stay in sync with Asset)
+- `Sources/Services/UpdateChecker.swift` — current GitHub Releases polling (to be removed in Phase 4 cutover)
+- `Sources/AppDelegate.swift` — menu bar wiring, update check integration
+- `scripts/build_dmg.sh` — DMG build pipeline (codesign, Info.plist, framework bundling in Phase 4)
+- `Package.swift` — SPM target structure (Sparkle dependency added in Phase 4)
+- `Tests/ClipTests/FolderTests.swift` — existing test pattern for Asset tree
+- `CLAUDE.md`, `AGENT_RULES.md` — project conventions
+
+### Related Solution Docs
+
+- `docs/solutions/best-practice/swift-cli-target-isolation-observable-pattern-20260408.md` — why VaultAsset exists, schema drift prevention
+- `docs/solutions/build-errors/spm-multi-target-shared-sources-path.md` — Package.swift `exclude:` pattern (applies when adding Sparkle dependency)
+- `docs/solutions/build-errors/spm-product-name-collision-case-insensitive-apfs-20260407.md` — case-insensitive filesystem gotcha
+- `docs/solutions/best-practice/swift-cli-clipboard-dmg-bundling-20260406.md` — NSPasteboard + codesign pattern
+- `docs/solutions/best-practice/open-source-readiness-swift-macos-20260406.md` — pre-release checklist
+- `docs/solutions/best-practice/cloudflare-pages-direct-upload-wrangler-20260408.md` — landing page redeploy workflow (post-release)
+- `docs/solutions/ui-bugs/nscolor-dynamic-provider-light-dark-20260405.md` — color palette pattern for any new UI
+
+### External References
+
+- Sparkle framework: https://sparkle-project.org/documentation/
+- Sparkle publishing guide: https://sparkle-project.org/documentation/publishing/
+- Sparkle customization keys: https://sparkle-project.org/documentation/customization/
+- Sparkle sandboxing notes: https://sparkle-project.org/documentation/sandboxing/
+- Sparkle EdDSA migration: https://sparkle-project.org/documentation/eddsa-migration/
+- Sparkle GitHub: https://github.com/sparkle-project/Sparkle
+- stats.store: https://stats.store
+- stats.store source: https://github.com/steipete/stats-store
+- "Code Signing and Notarization: Sparkle and Tears": https://steipete.me/posts/2025/code-signing-and-notarization-sparkle-and-tears
+- NSPasteboard UTType reference: https://developer.apple.com/documentation/uniformtypeidentifiers
+- NSOpenPanel: https://developer.apple.com/documentation/appkit/nsopenpanel
+
+### Related Issues
+
+- blacklogos/markutils#5 — Add auto-update support using Sparkle framework
+- blacklogos/markutils#6 — Add text search/grep for file names in folders
+- blacklogos/markutils#7 — Add copy as SVG and paste as PNG options for images
+- blacklogos/markutils#8 — feat: Preview a Markdown file with properly rendered format
+- blacklogos/markutils#9 — feat: Add a Markdown file to preview and format
+
+### Completed in v1.3.0 (context)
+
+- blacklogos/markutils#2 (split view), #3 (auto-update — simple GitHub checker, superseded by #5 here), #4 (export/import vault)


### PR DESCRIPTION
## Summary

- Vault search now recursively descends into folder children at any depth
- Matching descendants are flattened into the top-level results (Folders / Images / Text sections)
- Original `AssetStore.assets` are never mutated by the search filter
- 10 unit tests covering: top-level match, nested match (2+ levels deep), folder name match, content match, case-insensitive, no match, mutation safety

Closes #6

## Testing

- `swift test` — 14/14 pass (4 existing + 10 new `SearchTests`)
- `./scripts/verify_release.sh` — passes
- Manual: create a 3-level folder tree, search for a leaf name → leaf appears in results

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: pure client-side filter logic with no persistence, network, or state changes.

## Technical Approach

Extracted `AssetGridView.searchAssets(_:query:)` as a `static` method so tests can call it directly. The recursive `collectMatches` function:
1. Checks if the asset's name or content matches (case-insensitive substring)
2. If yes → appends to results and returns (folder is included whole)
3. If no and asset is a folder → recurse into children, flattening matches up

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)