### PR TITLE
feat: Markdown file preview, format tracking, and file picker

### DIFF
--- a/Sources/ClipCLI/main.swift
+++ b/Sources/ClipCLI/main.swift
@@ -92,6 +92,7 @@ struct VaultAsset: Codable {
     let imageData: Data?
     let name: String?
     let children: [VaultAsset]?
+    let fileFormat: String?
 }
 
 func vaultFileURL() -> URL {

--- a/Sources/Models/Asset.swift
+++ b/Sources/Models/Asset.swift
@@ -10,8 +10,9 @@ final class Asset: Identifiable, Codable {
     var imageData: Data?
     var name: String? // Optional name, especially for folders
     var children: [Asset]? // For recursive folder structure
-    
-    init(type: AssetType, textContent: String? = nil, imageData: Data? = nil, name: String? = nil, children: [Asset]? = nil) {
+    var fileFormat: String? // Canonical file extension without dot ("md", "txt", "json")
+
+    init(type: AssetType, textContent: String? = nil, imageData: Data? = nil, name: String? = nil, children: [Asset]? = nil, fileFormat: String? = nil) {
         self.id = UUID()
         self.creationDate = Date()
         self.type = type
@@ -19,14 +20,15 @@ final class Asset: Identifiable, Codable {
         self.imageData = imageData
         self.name = name
         self.children = children
+        self.fileFormat = fileFormat
     }
-    
-    
+
+
     // Explicit Codable conformance to avoid @Observable macro issues
     enum CodingKeys: String, CodingKey {
-        case id, creationDate, type, textContent, imageData, name, children
+        case id, creationDate, type, textContent, imageData, name, children, fileFormat
     }
-    
+
     required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(UUID.self, forKey: .id)
@@ -36,8 +38,9 @@ final class Asset: Identifiable, Codable {
         self.imageData = try container.decodeIfPresent(Data.self, forKey: .imageData)
         self.name = try container.decodeIfPresent(String.self, forKey: .name)
         self.children = try container.decodeIfPresent([Asset].self, forKey: .children)
+        self.fileFormat = try container.decodeIfPresent(String.self, forKey: .fileFormat)
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
@@ -47,6 +50,7 @@ final class Asset: Identifiable, Codable {
         try container.encodeIfPresent(imageData, forKey: .imageData)
         try container.encodeIfPresent(name, forKey: .name)
         try container.encodeIfPresent(children, forKey: .children)
+        try container.encodeIfPresent(fileFormat, forKey: .fileFormat)
     }
 }
 

--- a/Sources/Models/MarkdownPreviewRouter.swift
+++ b/Sources/Models/MarkdownPreviewRouter.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Observation
+
+/// Routes markdown content from the Asset vault to the Transform tab for preview.
+/// Set `pendingText` from any view, then the TransformerView consumes it on appear.
+@Observable
+final class MarkdownPreviewRouter {
+    static let shared = MarkdownPreviewRouter()
+    var pendingText: String? = nil
+
+    func request(_ text: String) {
+        pendingText = text
+    }
+
+    func consume() -> String? {
+        defer { pendingText = nil }
+        return pendingText
+    }
+}

--- a/Sources/Views/AssetGridView.swift
+++ b/Sources/Views/AssetGridView.swift
@@ -421,7 +421,8 @@ struct AssetGridView: View {
                 }
             } else if type.conforms(to: .text) || type.conforms(to: .plainText) || type.conforms(to: .sourceCode) {
                 if let data = try? Data(contentsOf: url), let text = String(data: data, encoding: .utf8) {
-                    return Asset(type: .text, textContent: text, name: name)
+                    let ext = url.pathExtension.lowercased()
+                    return Asset(type: .text, textContent: text, name: name, fileFormat: ext.isEmpty ? nil : ext)
                 }
             }
         }
@@ -472,6 +473,12 @@ struct AssetItemView: View {
         asset.name?.hasPrefix("Clipboard ") == true
     }
 
+    private var isMarkdownAsset: Bool {
+        guard asset.type == .text else { return false }
+        let fmt = asset.fileFormat ?? ""
+        return fmt == "md" || fmt == "markdown"
+    }
+
     var body: some View {
         VStack(spacing: 4) {
             ZStack(alignment: .topTrailing) {
@@ -501,6 +508,19 @@ struct AssetItemView: View {
                         .padding(3)
                         .background(Color.gray.opacity(0.7))
                         .clipShape(Circle())
+                        .padding(4)
+                }
+
+                // Markdown badge
+                if isMarkdownAsset {
+                    Text("MD")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(Color.blue.opacity(0.8))
+                        .clipShape(Capsule())
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
                         .padding(4)
                 }
 
@@ -564,6 +584,19 @@ struct AssetItemView: View {
             }
         }
         .contentShape(Rectangle())
+        .contextMenu {
+            Button("Copy") { copyAsset() }
+            if isMarkdownAsset {
+                Button("Preview Rendered") {
+                    if let text = asset.textContent {
+                        MarkdownPreviewRouter.shared.request(text)
+                    }
+                }
+            }
+            Divider()
+            Button("Rename") { startRename() }
+            Button("Delete", role: .destructive) { deleteAsset() }
+        }
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.1)) {
                 isHovering = hovering

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -8,6 +8,7 @@ struct ContentView: View {
     @State private var showOnboarding = false
     @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
     @State private var snippetStore = SnippetStore.shared
+    private var previewRouter = MarkdownPreviewRouter.shared
     
     enum AppTheme: String, CaseIterable, Identifiable {
         case system = "System"
@@ -96,6 +97,11 @@ struct ContentView: View {
         .onAppear {
             if !hasSeenOnboarding {
                 showOnboarding = true
+            }
+        }
+        .onChange(of: previewRouter.pendingText) { _, newValue in
+            if newValue != nil {
+                selectedTab = 1 // Switch to Transform tab
             }
         }
         .background(WindowAccessor { window in

--- a/Sources/Views/QuickActionsView.swift
+++ b/Sources/Views/QuickActionsView.swift
@@ -10,6 +10,7 @@ struct QuickActionsView: View {
     @State private var outputMode: OutputMode = .text
     @State private var showCopied = false
     @State private var splitVertical = false  // false = stacked, true = side-by-side
+    private var previewRouter = MarkdownPreviewRouter.shared
 
     enum OutputMode { case text, htmlPreview }
 
@@ -55,6 +56,15 @@ struct QuickActionsView: View {
             StatusBarView(text: input, cursorRange: nil)
         }
         .background(AppColors.windowBackground)
+        .onAppear { consumeRouterText() }
+        .onChange(of: previewRouter.pendingText) { _, _ in consumeRouterText() }
+    }
+
+    private func consumeRouterText() {
+        if let text = previewRouter.consume() {
+            input = text
+            outputMode = .htmlPreview
+        }
     }
 
     // MARK: - Input Pane
@@ -78,6 +88,12 @@ struct QuickActionsView: View {
                 }
 
                 Spacer()
+
+                Button(action: openMarkdownFile) {
+                    Image(systemName: "folder.badge.plus")
+                }
+                .buttonStyle(.plain)
+                .help("Open Markdown file…")
 
                 Button(action: pasteFromClipboard) {
                     Image(systemName: "doc.on.clipboard")
@@ -254,6 +270,30 @@ struct QuickActionsView: View {
     }
 
     // MARK: - Actions
+
+    private func openMarkdownFile() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        if let mdType = UTType(filenameExtension: "md") {
+            panel.allowedContentTypes = [mdType, .plainText]
+        } else {
+            panel.allowedContentTypes = [.plainText]
+        }
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            let text = try String(contentsOf: url, encoding: .utf8)
+            input = text
+            output = ""
+            outputMode = .htmlPreview
+        } catch {
+            let alert = NSAlert(error: error)
+            alert.runModal()
+        }
+    }
 
     private func pasteFromClipboard() {
         if let text = NSPasteboard.general.string(forType: .string) {

--- a/Tests/ClipTests/AssetFormatTests.swift
+++ b/Tests/ClipTests/AssetFormatTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import Clip
+
+final class AssetFormatTests: XCTestCase {
+
+    // MARK: - Backward Compatibility
+
+    func testDecodeOldJSONWithoutFileFormat() throws {
+        // Simulate JSON from v1.3.0 (no fileFormat field)
+        let json = """
+        {
+            "id": "550E8400-E29B-41D4-A716-446655440000",
+            "creationDate": 704067200,
+            "type": "text",
+            "textContent": "Hello",
+            "name": "greeting.txt"
+        }
+        """.data(using: .utf8)!
+
+        let asset = try JSONDecoder().decode(Asset.self, from: json)
+        XCTAssertEqual(asset.name, "greeting.txt")
+        XCTAssertEqual(asset.textContent, "Hello")
+        XCTAssertNil(asset.fileFormat, "Old assets should decode with nil fileFormat")
+    }
+
+    // MARK: - Encode/Decode Round-Trip
+
+    func testFileFormatRoundTrip() throws {
+        let asset = Asset(type: .text, textContent: "# README", name: "readme.md", fileFormat: "md")
+
+        let data = try JSONEncoder().encode(asset)
+        let decoded = try JSONDecoder().decode(Asset.self, from: data)
+
+        XCTAssertEqual(decoded.fileFormat, "md")
+        XCTAssertEqual(decoded.name, "readme.md")
+        XCTAssertEqual(decoded.textContent, "# README")
+    }
+
+    func testFileFormatNilRoundTrip() throws {
+        let asset = Asset(type: .text, textContent: "plain text", name: "note.txt")
+        XCTAssertNil(asset.fileFormat)
+
+        let data = try JSONEncoder().encode(asset)
+        let decoded = try JSONDecoder().decode(Asset.self, from: data)
+
+        XCTAssertNil(decoded.fileFormat)
+    }
+
+    // MARK: - VaultAsset Interop (CLI ↔ App)
+
+    func testVaultAssetDecodesFileFormat() throws {
+        // Encode as app Asset, decode as CLI VaultAsset
+        let asset = Asset(type: .text, textContent: "# Doc", name: "doc.md", fileFormat: "md")
+        let data = try JSONEncoder().encode(asset)
+
+        // VaultAsset is in the CLI target — we can't import it here.
+        // Instead, verify the JSON contains the fileFormat key.
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(json["fileFormat"] as? String, "md")
+    }
+
+    // MARK: - Markdown Detection Helper
+
+    func testMarkdownAssetDetection() {
+        let mdAsset = Asset(type: .text, textContent: "# Hello", name: "readme.md", fileFormat: "md")
+        let txtAsset = Asset(type: .text, textContent: "Hello", name: "note.txt", fileFormat: "txt")
+        let noFormatAsset = Asset(type: .text, textContent: "Hello", name: "note.txt")
+        let imgAsset = Asset(type: .image, imageData: Data(), name: "pic.png")
+
+        XCTAssertTrue(isMarkdown(mdAsset))
+        XCTAssertFalse(isMarkdown(txtAsset))
+        XCTAssertFalse(isMarkdown(noFormatAsset))
+        XCTAssertFalse(isMarkdown(imgAsset))
+    }
+
+    // Mirror the detection logic from AssetItemView
+    private func isMarkdown(_ asset: Asset) -> Bool {
+        guard asset.type == .text else { return false }
+        let fmt = asset.fileFormat ?? ""
+        return fmt == "md" || fmt == "markdown"
+    }
+}


### PR DESCRIPTION
## Summary
- `Asset.fileFormat: String?` tracks the original file extension (backward-compatible with v1.3.0 vaults)
- `VaultAsset` in CLI mirrors the field for `clip export`/`import` round-trip
- MD badge on text assets with `fileFormat == "md"` or `"markdown"`
- `MarkdownPreviewRouter` singleton routes text from vault → Transform tab with rendered preview
- "Preview Rendered" context menu action on markdown assets
- "Open File…" button in Transform tab opens NSOpenPanel filtered to `.md`/`.txt`

Closes #8, closes #9

## Testing
- 19/19 tests pass (5 new `AssetFormatTests` + 10 `SearchTests` + 4 existing)
- `./scripts/verify_release.sh` passes
- Tested: backward compat (old JSON without fileFormat decodes), round-trip, markdown detection

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: client-side schema extension and UI changes only.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)