### PR TITLE
feat: SVG copy, SVG drag-out, and Paste-as-PNG

### DIFF
--- a/Sources/Views/AssetGridView.swift
+++ b/Sources/Views/AssetGridView.swift
@@ -64,6 +64,12 @@ struct AssetGridView: View {
                 Text("Assets")
                     .font(.headline)
                 Spacer()
+                Button(action: pasteAsPNG) {
+                    Label("Paste PNG", systemImage: "doc.on.clipboard")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
                 Button(action: { showFileImporter = true }) {
                     Label("Add Files", systemImage: "plus.circle")
                 }
@@ -247,6 +253,14 @@ struct AssetGridView: View {
                 return nil
             }
         } else if asset.type == .text, let text = asset.textContent {
+            // Register SVG type for drag-out to design tools
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.hasPrefix("<svg") || trimmed.hasPrefix("<?xml") {
+                provider.registerDataRepresentation(forTypeIdentifier: "public.svg-image", visibility: .all) { completion in
+                    completion(text.data(using: .utf8), nil)
+                    return nil
+                }
+            }
             provider.registerDataRepresentation(forTypeIdentifier: UTType.plainText.identifier, visibility: .all) { completion in
                 completion(text.data(using: .utf8), nil)
                 return nil
@@ -395,6 +409,23 @@ struct AssetGridView: View {
         }
     }
     
+    private func pasteAsPNG() {
+        let pb = NSPasteboard.general
+        guard let image = NSImage(pasteboard: pb),
+              let tiff = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff),
+              let png = bitmap.representation(using: .png, properties: [:]) else {
+            let alert = NSAlert()
+            alert.messageText = "Nothing to paste"
+            alert.informativeText = "Clipboard doesn't contain an image."
+            alert.alertStyle = .informational
+            alert.runModal()
+            return
+        }
+        let asset = Asset(type: .image, imageData: png, name: "Pasted Image")
+        store.add(asset)
+    }
+
     private func createAsset(from url: URL) -> Asset? {
         var isDirectory: ObjCBool = false
         guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else { return nil }
@@ -586,6 +617,9 @@ struct AssetItemView: View {
         .contentShape(Rectangle())
         .contextMenu {
             Button("Copy") { copyAsset() }
+            if isSVGAsset {
+                Button("Copy as SVG") { copyAsset() }
+            }
             if isMarkdownAsset {
                 Button("Preview Rendered") {
                     if let text = asset.textContent {
@@ -616,6 +650,12 @@ struct AssetItemView: View {
         isRenaming = false
     }
 
+    private var isSVGAsset: Bool {
+        guard asset.type == .text, let text = asset.textContent else { return false }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.hasPrefix("<svg") || trimmed.hasPrefix("<?xml")
+    }
+
     private func copyAsset() {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
@@ -623,6 +663,9 @@ struct AssetItemView: View {
         if asset.type == .image, let data = asset.imageData {
             pasteboard.setData(data, forType: .png)
         } else if asset.type == .text, let text = asset.textContent {
+            if isSVGAsset {
+                pasteboard.setString(text, forType: NSPasteboard.PasteboardType("public.svg-image"))
+            }
             pasteboard.setString(text, forType: .string)
         }
 
@@ -757,27 +800,31 @@ struct CompactAssetRowView: View {
         isRenaming = false
     }
     
+    private var isSVGAsset: Bool {
+        guard asset.type == .text, let text = asset.textContent else { return false }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.hasPrefix("<svg") || trimmed.hasPrefix("<?xml")
+    }
+
     private func copyAsset() {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
-        
+
         if asset.type == .image, let data = asset.imageData {
             pasteboard.setData(data, forType: .png)
         } else if asset.type == .text, let text = asset.textContent {
+            if isSVGAsset {
+                pasteboard.setString(text, forType: NSPasteboard.PasteboardType("public.svg-image"))
+            }
             pasteboard.setString(text, forType: .string)
         }
-        
-        withAnimation {
-            showCopiedFeedback = true
-        }
-        
+
+        withAnimation { showCopiedFeedback = true }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-            withAnimation {
-                showCopiedFeedback = false
-            }
+            withAnimation { showCopiedFeedback = false }
         }
     }
-    
+
     private func deleteAsset() {
         withAnimation {
             store.delete(asset)

--- a/Tests/ClipTests/ImageFormatTests.swift
+++ b/Tests/ClipTests/ImageFormatTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import Clip
+
+final class ImageFormatTests: XCTestCase {
+
+    // MARK: - SVG Detection
+
+    func testSVGDetectionWithSvgTag() {
+        XCTAssertTrue(isSVG("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\"></svg>"))
+    }
+
+    func testSVGDetectionWithXmlDeclaration() {
+        XCTAssertTrue(isSVG("<?xml version=\"1.0\"?><svg></svg>"))
+    }
+
+    func testSVGDetectionWithLeadingWhitespace() {
+        XCTAssertTrue(isSVG("  \n  <svg></svg>"))
+    }
+
+    func testSVGDetectionNegativeForHTML() {
+        XCTAssertFalse(isSVG("<html><body>Hello</body></html>"))
+    }
+
+    func testSVGDetectionNegativeForPlainText() {
+        XCTAssertFalse(isSVG("Hello world"))
+    }
+
+    func testSVGDetectionNegativeForEmpty() {
+        XCTAssertFalse(isSVG(""))
+    }
+
+    func testSVGDetectionNegativeForMarkdown() {
+        XCTAssertFalse(isSVG("# Hello\n**bold**"))
+    }
+
+    // MARK: - PNG Conversion (basic)
+
+    func testPNGFromImageData() throws {
+        // Create a 1x1 red PNG programmatically
+        let image = NSImage(size: NSSize(width: 1, height: 1))
+        image.lockFocus()
+        NSColor.red.drawSwatch(in: NSRect(x: 0, y: 0, width: 1, height: 1))
+        image.unlockFocus()
+
+        guard let tiff = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff),
+              let png = bitmap.representation(using: .png, properties: [:]) else {
+            XCTFail("Failed to create PNG from NSImage")
+            return
+        }
+
+        XCTAssertTrue(png.count > 0)
+        // Verify PNG magic bytes
+        let magic = [UInt8](png.prefix(4))
+        XCTAssertEqual(magic, [0x89, 0x50, 0x4E, 0x47]) // PNG signature
+    }
+
+    // MARK: - Helper (mirrors AssetItemView logic)
+
+    private func isSVG(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.hasPrefix("<svg") || trimmed.hasPrefix("<?xml")
+    }
+}


### PR DESCRIPTION
## Summary
- Copy-as-SVG for text assets containing SVG markup (registers `public.svg-image` on pasteboard)
- "Copy as SVG" context menu item shown only on SVG text assets
- SVG drag-out via NSItemProvider for design tool interop
- "Paste PNG" toolbar button converts clipboard images to PNG assets
- Error alert when clipboard is empty/non-image
- 8 new tests for SVG detection and PNG conversion

Closes #7

## Testing
- 27/27 tests pass (8 new `ImageFormatTests`)
- `./scripts/verify_release.sh` passes

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: client-side pasteboard operations only.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)